### PR TITLE
Fixed EnhancedMaptile midlayer not properly rendering

### DIFF
--- a/src/EnhancedMapTiles/Gate.java
+++ b/src/EnhancedMapTiles/Gate.java
@@ -27,5 +27,13 @@ public class Gate extends EnhancedMapTile {
                 .build();
         return new GameObject(x, y, frame);
     }
+
+    @Override
+    protected GameObject loadMidLayer(SpriteSheet spriteSheet) {
+        Frame frame = new FrameBuilder(spriteSheet.getSubImage(0, 0))
+                .withScale(1)
+                .build();
+        return new GameObject(x, y, frame);
+    }
     
 }

--- a/src/Level/Camera.java
+++ b/src/Level/Camera.java
@@ -223,8 +223,8 @@ public class Camera extends Rectangle {
         }
 
         for (EnhancedMapTile enhancedMapTile : activeEnhancedMapTiles) {
-            if (containsDraw(enhancedMapTile) && enhancedMapTile.getTopLayer() != null) {
-                enhancedMapTile.drawTopLayer(graphicsHandler);
+            if (containsDraw(enhancedMapTile) && enhancedMapTile.getMidLayer() != null) {
+                enhancedMapTile.drawMidLayer(graphicsHandler);
             }
         }
     }


### PR DESCRIPTION
Dawyt's Gate object now loads a mid layer so MapTile midlayers do not overwrite